### PR TITLE
Fix bug with fields not being omitted despite explicitly declared so

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,11 +67,9 @@ function KeystoneRest() {
     // deleted.
     object = model.toObject ? model.toObject() : model;
 
-    _.each(omitted, function (field) {
-      if (object[field]) { delete object[field]; }
-    });
+    var args = [object].concat(omitted);
+    return _.omit.apply(null, args);
 
-    return object;
   };
 
 


### PR DESCRIPTION
I rewrote `_removeOmitted` to use underscore's `omit` method, since the current implementation won't omit fields that were declared on the prototype (like `__v`)

BTW, I'm sorry to bombard you with PR's!
