### PR TITLE
Fixed TypeError: Cannot read property 'ref' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function KeystoneRest() {
       var schemaField = model.schema.paths[key];
 
       // return if value is a string
-      if (typeof field === 'string' || !schemaField) { return; }
+      if (typeof field === 'string' || !schemaField || _.isEmpty(schemaField)) { return; }
 
       if (schemaField.options.ref) {
         body[key] = field._id;


### PR DESCRIPTION
Fixed "TypeError: Cannot read property 'ref' of undefined" when "schemaField == {}". 
Just seemed to happen in newer versions of node.js such as v0.12.0.